### PR TITLE
Fixes for swagger and naming on endpoints

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -44,13 +44,22 @@ type ContainerParam struct {
 	Name string `json:"container"`
 }
 
-// swagger:parameters istioConfigList workloadList workloadDetails serviceDetails spansList tracesList errorTraces tracesDetail workloadValidations appList serviceMetrics appMetrics workloadMetrics istioConfigDetails istioConfigDetailsSubtype istioConfigDelete istioConfigDeleteSubtype istioConfigUpdate istioConfigUpdateSubtype serviceList appDetails graphApp graphAppVersion graphNamespace graphService graphWorkload namespaceMetrics customDashboard appDashboard serviceDashboard workloadDashboard istioConfigCreate istioConfigCreateSubtype namespaceTls podDetails podLogs getThreeScaleService postThreeScaleService patchThreeScaleService deleteThreeScaleService namespaceValidations
+// swagger:parameters istioConfigList workloadList workloadDetails serviceDetails spansList tracesList errorTraces tracesDetail workloadValidations appList serviceMetrics appMetrics workloadMetrics istioConfigDetails istioConfigDetailsSubtype istioConfigDelete istioConfigDeleteSubtype istioConfigUpdate istioConfigUpdateSubtype serviceList appDetails graphApp graphAppVersion graphNamespace graphService graphWorkload namespaceMetrics customDashboard appDashboard serviceDashboard workloadDashboard istioConfigCreate istioConfigCreateSubtype namespaceTls podDetails podLogs getThreeScaleService postThreeScaleService patchThreeScaleService deleteThreeScaleService namespaceValidations getIter8Experiments postIter8Experiments patchIter8Experiments deleteIter8Experiments
 type NamespaceParam struct {
 	// The namespace name.
 	//
 	// in: path
 	// required: true
 	Name string `json:"namespace"`
+}
+
+// swagger:parameters getIter8Experiments patchIter8Experiments deleteIter8Experiments
+type NameParam struct {
+	// The name param
+	//
+	// in: path
+	// required: true
+	Name string `json:"name"`
 }
 
 // swagger:parameters istioConfigDetails istioConfigDetailsSubtype istioConfigDelete istioConfigDeleteSubtype istioConfigUpdate istioConfigUpdateSubtype
@@ -666,4 +675,25 @@ type ThreeScaleGetRuleResponse struct {
 type swaggIstioConfigPermissions struct {
 	// in:body
 	Body models.IstioConfigPermissions
+}
+
+// Return Iter8 Info
+// swagger:response iter8StatusResponse
+type Iter8StatusResponse struct {
+	// in: body
+	Body models.Iter8Info
+}
+
+// Return a Iter8 Experiment detail
+// swagger:response iter8ExperimentGetDetailResponse
+type Iter8ExperimentGetDetailResponse struct {
+	// in: body
+	Body models.Iter8ExperimentDetail
+}
+
+// Return a list of Iter8 Experiment Items
+// swagger:response iter8ExperimentsGetResponse
+type Iter8ExperimentsResponnse struct {
+	// in: body
+	Body []models.Iter8ExperimentItem
 }

--- a/models/iter8.go
+++ b/models/iter8.go
@@ -14,20 +14,20 @@ type Iter8Info struct {
 }
 
 type Iter8ExperimentItem struct {
-	Name                	string `json:"name"`
-	Phase               	string `json:"phase"`
-	CreatedAt           	string `json:"createdAt"`
-	Status              	string `json:"status"`
-	Baseline            	string `json:"baseline"`
-	BaselinePercentage  	int    `json:"baselinePercentage"`
-	Candidate           	string `json:"candidate"`
-	CandidatePercentage 	int    `json:"candidatePercentage"`
-	Namespace           	string `json:"namespace"`
-	StartedAt				string `json:"startedAt"`
-	EndedAt					string `json:"endedAt"`
-	TargetService 			string `json:"targetService"`
-	TargetServiceNamespace 	string `json:"targetServiceNamespace"`
-	AssessmentConclusion 	string `json:"assessmentConclusion"`
+	Name                   string `json:"name"`
+	Phase                  string `json:"phase"`
+	CreatedAt              string `json:"createdAt"`
+	Status                 string `json:"status"`
+	Baseline               string `json:"baseline"`
+	BaselinePercentage     int    `json:"baselinePercentage"`
+	Candidate              string `json:"candidate"`
+	CandidatePercentage    int    `json:"candidatePercentage"`
+	Namespace              string `json:"namespace"`
+	StartedAt              string `json:"startedAt"`
+	EndedAt                string `json:"endedAt"`
+	TargetService          string `json:"targetService"`
+	TargetServiceNamespace string `json:"targetServiceNamespace"`
+	AssessmentConclusion   string `json:"assessmentConclusion"`
 }
 
 type Iter8ExperimentDetail struct {
@@ -112,13 +112,13 @@ func (i *Iter8ExperimentDetail) Parse(iter8Object kubernetes.Iter8Experiment) {
 		TrafficStepSize:      spec.TrafficControl.TrafficStepSize,
 	}
 
-	startTime, _:= strconv.ParseInt(status.StartTimeStamp,10, 64)
-	startTimeString  :=  time.Unix(0, startTime*int64(1000000)).Format(time.RFC1123)
-	endTimeString  := ""
-	if  status.EndTimestamp != "" {
-		_endTime, _:= strconv.ParseInt(status.EndTimestamp,10, 64)
-		endTimeInNano :=  _endTime*int64(1000000)
-		endTimeString = time.Unix(0, endTimeInNano ).Format(time.RFC1123)
+	startTime, _ := strconv.ParseInt(status.StartTimeStamp, 10, 64)
+	startTimeString := time.Unix(0, startTime*int64(1000000)).Format(time.RFC1123)
+	endTimeString := ""
+	if status.EndTimestamp != "" {
+		_endTime, _ := strconv.ParseInt(status.EndTimestamp, 10, 64)
+		endTimeInNano := _endTime * int64(1000000)
+		endTimeString = time.Unix(0, endTimeInNano).Format(time.RFC1123)
 	}
 	targetServiceNamespace := spec.TargetService.Namespace
 	if targetServiceNamespace == "" {
@@ -126,18 +126,18 @@ func (i *Iter8ExperimentDetail) Parse(iter8Object kubernetes.Iter8Experiment) {
 	}
 
 	i.ExperimentItem = Iter8ExperimentItem{
-		Name:                	iter8Object.GetObjectMeta().Name,
-		Phase:				 	status.Phase,
-		Status:              	status.Message,
-		Baseline:            	spec.TargetService.Baseline,
-		BaselinePercentage:  	status.TrafficSplitPercentage.Baseline,
-		Candidate:           	spec.TargetService.Candidate,
-		CandidatePercentage: 	status.TrafficSplitPercentage.Candidate,
-		StartedAt:	         	startTimeString,
-		EndedAt:			 	endTimeString,
-		TargetService: 		 	spec.TargetService.Name,
+		Name:                   iter8Object.GetObjectMeta().Name,
+		Phase:                  status.Phase,
+		Status:                 status.Message,
+		Baseline:               spec.TargetService.Baseline,
+		BaselinePercentage:     status.TrafficSplitPercentage.Baseline,
+		Candidate:              spec.TargetService.Candidate,
+		CandidatePercentage:    status.TrafficSplitPercentage.Candidate,
+		StartedAt:              startTimeString,
+		EndedAt:                endTimeString,
+		TargetService:          spec.TargetService.Name,
 		TargetServiceNamespace: targetServiceNamespace,
-		AssessmentConclusion: strings.Join(status.Assestment.Conclusions, ";"),
+		AssessmentConclusion:   strings.Join(status.Assestment.Conclusions, ";"),
 	}
 	i.CriteriaDetails = criterias
 	i.TrafficControl = trafficControl

--- a/routing/routes.go
+++ b/routing/routes.go
@@ -1306,7 +1306,7 @@ func NewRoutes() (r *Routes) {
 			handlers.ThreeScaleServiceRuleDelete,
 			true,
 		},
-		// swagger:route GET /iter8 getIter8Info
+		// swagger:route GET /iter8
 		// ---
 		// Endpoint to check if threescale adapter is present in the cluster and if user can write adapter config
 		//
@@ -1317,7 +1317,7 @@ func NewRoutes() (r *Routes) {
 		//
 		// responses:
 		//		500: internalError
-		//		200: iter8InfoResponse
+		//		200: iter8StatusResponse
 		{
 			"Iter8Info",
 			"GET",
@@ -1325,7 +1325,7 @@ func NewRoutes() (r *Routes) {
 			handlers.Iter8Status,
 			true,
 		},
-		// swagger:route GET /iter8/namespaces/{namespace}/experiments/{name} getexperiments
+		// swagger:route GET /iter8/namespaces/{namespace}/experiments/{name} getIter8Experiments
 		// ---
 		// Endpoint to fetch iter8 experiments by namespace and name
 		//
@@ -1336,7 +1336,7 @@ func NewRoutes() (r *Routes) {
 		//
 		// responses:
 		//		500: internalError
-		//		200: iter8experimentdetail
+		//		200: iter8ExperimentGetDetailResponse
 		{
 			"Iter8ExperimentsByNamespaceAndName",
 			"GET",
@@ -1344,7 +1344,7 @@ func NewRoutes() (r *Routes) {
 			handlers.Iter8ExperimentGet,
 			true,
 		},
-		// swagger:route GET /iter8/experiments getexperiments
+		// swagger:route GET /iter8/experiments
 		// ---
 		// Endpoint to fetch iter8 experiments for all namespaces user have access.
 		// User can define a comman separated list of namespaces.
@@ -1356,7 +1356,7 @@ func NewRoutes() (r *Routes) {
 		//
 		// responses:
 		//		500: internalError
-		//		200: iter8experiments
+		//		200: iter8GetExperimentsResponse
 		{
 			"Iter8Experiments",
 			"GET",
@@ -1365,7 +1365,7 @@ func NewRoutes() (r *Routes) {
 			true,
 		},
 
-		// swagger:route POST /iter8/experiment postexperiment
+		// swagger:route POST /iter8/namespaces/{namespace}/experiments postIter8Experiments
 		// ---
 		// Endpoint to create new iter8 experiments for a given namespace.
 		//
@@ -1376,15 +1376,15 @@ func NewRoutes() (r *Routes) {
 		//
 		// responses:
 		//		500: internalError
-		//		200: iter8experimentdetail
+		//		200: iter8ExperimentsGetResponse
 		{
-			Name:          "Iter8ExpreimentCreate",
+			Name:          "Iter8ExperimentCreate",
 			Method:        "POST",
 			Pattern:       "/api/iter8/namespaces/{namespace}/experiments",
 			HandlerFunc:   handlers.Iter8ExperimentCreate,
 			Authenticated: true,
 		},
-		// swagger:route PATCH /iter8/experiments
+		// swagger:route PATCH /iter8/experiments/{namespace}/name/{name} patchIter8Experiments
 		// ---
 		// Endpoint to update new iter8 experiment (for abort purpose)
 		//
@@ -1395,15 +1395,15 @@ func NewRoutes() (r *Routes) {
 		//
 		// responses:
 		//		500: internalError
-		//		200: iter8experimentdetail
+		//		200: iter8ExperimentGetDetailResponse
 		{
-			Name:          "Iter8ExpreimentUpdate",
+			Name:          "Iter8ExperimentsUpdate",
 			Method:        "PATCH",
-			Pattern:       "/api/iter8/experiment/namespaces/{namespace}/name/{name}",
+			Pattern:       "/api/iter8/experiments/namespaces/{namespace}/name/{name}",
 			HandlerFunc:   handlers.Iter8ExperimentUpdate,
 			Authenticated: true,
 		},
-		// swagger:route DELETE /iter8/experiment deleteexperiment
+		// swagger:route DELETE /iter8/experiments/namespaces/{namespace}/name/{name} deleteIter8Experiments
 		// ---
 		// Endpoint to delete   iter8 experiments
 		//
@@ -1414,11 +1414,11 @@ func NewRoutes() (r *Routes) {
 		//
 		// responses:
 		//		500: internalError
-		//		200: iter8experimentdetail
+		//		200
 		{
-			Name:          "Iter8ExpreimentDelete",
+			Name:          "Iter8ExperimentDelete",
 			Method:        "DELETE",
-			Pattern:       "/api/iter8/experiment/namespaces/{namespace}/name/{name}",
+			Pattern:       "/api/iter8/experiments/namespaces/{namespace}/name/{name}",
 			HandlerFunc:   handlers.Iter8ExperimentDelete,
 			Authenticated: true,
 		},

--- a/swagger.json
+++ b/swagger.json
@@ -179,6 +179,151 @@
         }
       }
     },
+    "/iter8/experiments/namespaces/{namespace}/name/{name}": {
+      "delete": {
+        "description": "Endpoint to delete   iter8 experiments",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "operationId": "deleteIter8Experiments",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The namespace name.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The name param",
+            "name": "name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "500": {
+            "$ref": "#/responses/internalError"
+          }
+        }
+      }
+    },
+    "/iter8/experiments/{namespace}/name/{name}": {
+      "patch": {
+        "description": "Endpoint to update new iter8 experiment (for abort purpose)",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "operationId": "patchIter8Experiments",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The namespace name.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The name param",
+            "name": "name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/iter8ExperimentGetDetailResponse"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          }
+        }
+      }
+    },
+    "/iter8/namespaces/{namespace}/experiments": {
+      "post": {
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "summary": "Endpoint to create new iter8 experiments for a given namespace.",
+        "operationId": "postIter8Experiments",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The namespace name.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/iter8ExperimentsGetResponse"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          }
+        }
+      }
+    },
+    "/iter8/namespaces/{namespace}/experiments/{name}": {
+      "get": {
+        "description": "Endpoint to fetch iter8 experiments by namespace and name",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "operationId": "getIter8Experiments",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The namespace name.",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "The name param",
+            "name": "name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/iter8ExperimentGetDetailResponse"
+          },
+          "500": {
+            "$ref": "#/responses/internalError"
+          }
+        }
+      }
+    },
     "/jaeger": {
       "get": {
         "description": "Get the jaeger URL and other descriptors",
@@ -4128,6 +4273,197 @@
       "title": "IstioValidations represents a set of IstioValidation grouped by IstioValidationKey.",
       "x-go-package": "github.com/kiali/kiali/models"
     },
+    "Iter8Criteria": {
+      "type": "object",
+      "properties": {
+        "metric": {
+          "type": "string",
+          "x-go-name": "Metric"
+        },
+        "sampleSize": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "SampleSize"
+        },
+        "stopOnFailure": {
+          "type": "boolean",
+          "x-go-name": "StopOnFailure"
+        },
+        "tolerance": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "Tolerance"
+        },
+        "toleranceType": {
+          "type": "string",
+          "x-go-name": "ToleranceType"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "Iter8CriteriaDetail": {
+      "type": "object",
+      "properties": {
+        "criteria": {
+          "$ref": "#/definitions/Iter8Criteria"
+        },
+        "metric": {
+          "$ref": "#/definitions/Iter8Metric"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "Iter8ExperimentDetail": {
+      "type": "object",
+      "properties": {
+        "criterias": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Iter8CriteriaDetail"
+          },
+          "x-go-name": "CriteriaDetails"
+        },
+        "experimentItem": {
+          "$ref": "#/definitions/Iter8ExperimentItem"
+        },
+        "trafficControl": {
+          "$ref": "#/definitions/Iter8TrafficControl"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "Iter8ExperimentItem": {
+      "type": "object",
+      "properties": {
+        "assessmentConclusion": {
+          "type": "string",
+          "x-go-name": "AssessmentConclusion"
+        },
+        "baseline": {
+          "type": "string",
+          "x-go-name": "Baseline"
+        },
+        "baselinePercentage": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "BaselinePercentage"
+        },
+        "candidate": {
+          "type": "string",
+          "x-go-name": "Candidate"
+        },
+        "candidatePercentage": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "CandidatePercentage"
+        },
+        "createdAt": {
+          "type": "string",
+          "x-go-name": "CreatedAt"
+        },
+        "endedAt": {
+          "type": "string",
+          "x-go-name": "EndedAt"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "namespace": {
+          "type": "string",
+          "x-go-name": "Namespace"
+        },
+        "phase": {
+          "type": "string",
+          "x-go-name": "Phase"
+        },
+        "startedAt": {
+          "type": "string",
+          "x-go-name": "StartedAt"
+        },
+        "status": {
+          "type": "string",
+          "x-go-name": "Status"
+        },
+        "targetService": {
+          "type": "string",
+          "x-go-name": "TargetService"
+        },
+        "targetServiceNamespace": {
+          "type": "string",
+          "x-go-name": "TargetServiceNamespace"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "Iter8Info": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "x-go-name": "Enabled"
+        },
+        "permissions": {
+          "$ref": "#/definitions/ResourcePermissions"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "Iter8Metric": {
+      "type": "object",
+      "properties": {
+        "absent_value": {
+          "type": "string",
+          "x-go-name": "AbsentValue"
+        },
+        "is_counter": {
+          "type": "boolean",
+          "x-go-name": "IsCounter"
+        },
+        "query_template": {
+          "type": "string",
+          "x-go-name": "QueryTemplate"
+        },
+        "sample_size_template": {
+          "type": "string",
+          "x-go-name": "SampleSizeTemplate"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
+    "Iter8TrafficControl": {
+      "type": "object",
+      "properties": {
+        "algorithm": {
+          "type": "string",
+          "x-go-name": "Algorithm"
+        },
+        "interval": {
+          "type": "string",
+          "x-go-name": "Interval"
+        },
+        "maxIteration": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "MaxIteration"
+        },
+        "maxTrafficPercentage": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "MaxTrafficPercentage"
+        },
+        "trafficStepSize": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "TrafficStepSize"
+        }
+      },
+      "x-go-package": "github.com/kiali/kiali/models"
+    },
     "JaegerInfo": {
       "type": "object",
       "properties": {
@@ -6681,6 +7017,27 @@
       "description": "Return caller permissions per namespace and Istio Config type",
       "schema": {
         "$ref": "#/definitions/IstioConfigPermissions"
+      }
+    },
+    "iter8ExperimentGetDetailResponse": {
+      "description": "Return a Iter8 Experiment detail",
+      "schema": {
+        "$ref": "#/definitions/Iter8ExperimentDetail"
+      }
+    },
+    "iter8ExperimentsGetResponse": {
+      "description": "Return a list of Iter8 Experiment Items",
+      "schema": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Iter8ExperimentItem"
+        }
+      }
+    },
+    "iter8StatusResponse": {
+      "description": "Return Iter8 Info",
+      "schema": {
+        "$ref": "#/definitions/Iter8Info"
       }
     },
     "jaegerInfoResponse": {


### PR DESCRIPTION
@jadeyliu939 I've fixed swagger to make CI to pass, also some changes in the handlers naming.
Basically we follow the convention to use always plurals for verbs when it return one or many.

Let me know what do you think.